### PR TITLE
Update application.yaml

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -6,6 +6,14 @@ metadata:
     description: This template creates a Build Configuration using an S2I builder.
     tags: instant-app
 parameters:
+  - name: SUFFIX_NAME
+    description: The suffix name for the template objects
+    displayName: Suffix name
+    value: ''
+  - name: RELEASE_VERSION
+    description: The release version number of application
+    displayName: Release version
+    value: 1.2.3
   - name: SOURCE_REPOSITORY_URL
     description: The source URL for the application
     displayName: Source URL
@@ -15,11 +23,6 @@ parameters:
     displayName: Source Branch
     value: master
     required: true
-  - name: SOURCE_REPOSITORY_DIR
-    description: The location within the source repo of the application
-    displayName: Source Directory
-    value: .
-    required: true
   - name: GITHUB_WEBHOOK_SECRET
     description: A secret string used to configure the GitHub webhook.
     displayName: GitHub Webhook Secret
@@ -27,30 +30,24 @@ parameters:
     from: '[a-zA-Z0-9]{40}'
     generate: expression
 objects:
-  - apiVersion: v1
+  - apiVersion: image.openshift.io/v1
     kind: ImageStream
     metadata:
-      name: nodejs-rest-http-redhat
+      name: nodejs-rest-http-redhat${SUFFIX_NAME}
+      labels:
+        version: ${RELEASE_VERSION}
     spec: {}
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: runtime
-    spec:
-      tags:
-        - name: latest
-          from:
-            kind: DockerImage
-            name: 'registry.access.redhat.com/rhoar-nodejs/nodejs-8:latest'
   - apiVersion: v1
     kind: BuildConfig
     metadata:
-      name: nodejs-rest-http-redhat
+      name: nodejs-rest-http-redhat-s2i${SUFFIX_NAME}
+      labels:
+        version: ${RELEASE_VERSION}
     spec:
       output:
         to:
           kind: ImageStreamTag
-          name: 'nodejs-rest-http-redhat:latest'
+          name: 'nodejs-rest-http-redhat${SUFFIX_NAME}:${RELEASE_VERSION}'
       postCommit: {}
       resources: {}
       source:
@@ -62,16 +59,14 @@ objects:
         type: Source
         sourceStrategy:
           from:
-            kind: ImageStreamTag
-            name: 'runtime:latest'
+            kind: DockerImage
+            name: 'registry.access.redhat.com/rhoar-nodejs/nodejs-8:latest'
           incremental: true
       triggers:
         - github:
             secret: '${GITHUB_WEBHOOK_SECRET}'
           type: GitHub
         - type: ConfigChange
-        - imageChange: {}
-          type: ImageChange
     status:
       lastVersion: 0
   - apiVersion: v1
@@ -81,8 +76,8 @@ objects:
         expose: 'true'
         project: nodejs-rest-http-redhat
         provider: nodeshift
-        version: 1.2.3
-      name: nodejs-rest-http-redhat
+        version: ${RELEASE_VERSION}
+      name: nodejs-rest-http-redhat${SUFFIX_NAME}
     spec:
       ports:
         - protocol: TCP
@@ -95,12 +90,12 @@ objects:
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:
-      name: nodejs-rest-http-redhat
+      name: nodejs-rest-http-redhat${SUFFIX_NAME}
       labels:
         app: nodejs-rest-http-redhat
         provider: nodeshift
         project: nodejs-rest-http-redhat
-        version: 1.2.3
+        version: ${RELEASE_VERSION}
     spec:
       template:
         spec:
@@ -117,7 +112,7 @@ objects:
                   scheme: HTTP
                 initialDelaySeconds: 60
                 periodSeconds: 30
-              image: nodejs-rest-http-redhat
+              image: ""
               name: nodejs-rest-http-redhat
               securityContext:
                 privileged: false
@@ -130,7 +125,7 @@ objects:
             app: nodejs-rest-http-redhat
             project: nodejs-rest-http-redhat
             provider: nodeshift
-            version: 1.2.3
+            version: ${RELEASE_VERSION}
       replicas: 1
       selector:
         app: nodejs-rest-http-redhat
@@ -145,18 +140,18 @@ objects:
               - nodejs-rest-http-redhat
             from:
               kind: ImageStreamTag
-              name: 'nodejs-rest-http-redhat:latest'
+              name: 'nodejs-rest-http-redhat${SUFFIX_NAME}:${RELEASE_VERSION}'
   - apiVersion: v1
     kind: Route
     metadata:
       labels:
         project: nodejs-rest-http-redhat
         provider: nodeshift
-        version: 1.2.3
-      name: nodejs-rest-http-redhat
+        version: ${RELEASE_VERSION}
+      name: nodejs-rest-http-redhat${SUFFIX_NAME}
     spec:
       port:
         targetPort: 8080
       to:
         kind: Service
-        name: nodejs-rest-http-redhat
+        name: nodejs-rest-http-redhat${SUFFIX_NAME}


### PR DESCRIPTION
Updating application.yaml according to openshift.io use case

Changes did -

1. Adds parameter - RELEASE_VERSION which is basically the
build number and will be used to differentiate between
the resources of the particular build.

2. Adds parameter - SUFFIX_NAME which is an identifier to
differentiate between the master build or other branches.
More like a master build or PR build. So whenever there is
a change in the resources of a particular branch, it applies
to the resource of that branch only. The SUFFIX_NAME variable
is used in the name of all resources.

3. Removes image stream for s2i base Docker image because it
will trigger a build whenever change that is not our use case
and also may be breaking sometime for the user or while
processing template it is creating two builds.

4. Adds a field label in image stream to tag the images
generated with the RELEASE_VERSION.

5. Removes `imageChange type` trigger from build config because
we kept at one place in deployment Config. Keeping at both
places are triggering two deployments